### PR TITLE
Correct entry for SPIKE to unpackaged

### DIFF
--- a/kali-tools.nix
+++ b/kali-tools.nix
@@ -320,7 +320,7 @@ in
   sniffjoke = todo;
   snmpcheck = pkgs.net-snmp;
   spectools = todo;
-  spike = pkgs.spike;
+  spike = cantfind;
   spooftooph = todo;
   sqldict = todo;
   sqlitebrowser = pkgs.sqlitebrowser;


### PR DESCRIPTION
SPIKE is not present in Nixpkgs as of 21.11 nor in any NUR repo as of https://github.com/nix-community/nur-combined/commit/06fb0a48cc26985f7dc9a035523a10f0ec5ea8ee.

If some future human wants to package it, there's [this fork](https://github.com/guilhermeferreira/spikepp/commits/master) (dead) and [Kali's fork](https://gitlab.com/kalilinux/packages/spike/-/commits/kali/master) (less dead), and despite the homepage disappearing the [original source for 2.9](https://www.immunitysec.com/downloads/SPIKE2.9.tgz) is still up.

resolves #11